### PR TITLE
Add support for mixing Clang and GCC (as NVCC host).

### DIFF
--- a/src/celeritas/optical/gen/OffloadAction.cc
+++ b/src/celeritas/optical/gen/OffloadAction.cc
@@ -119,14 +119,39 @@ void OffloadAction<G>::step_impl(CoreParams const& core_params,
 
 //---------------------------------------------------------------------------//
 /*!
+ * Get the pre-step auxiliary data for this action.
+ */
+template<GeneratorType G>
+template<MemSpace M>
+typename OffloadAction<G>::PreTraitsT::template Data<Ownership::reference, M>&
+OffloadAction<G>::get_pre_step_data(CoreState<M>& state) const
+{
+    return state.template aux_data<PreTraitsT::template Data>(
+        data_.pre_step_id);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Get the pre-post-step auxiliary data for this action.
+ */
+template<GeneratorType G>
+template<MemSpace M>
+typename OffloadAction<G>::PostTraitsT::template Data<Ownership::reference, M>&
+OffloadAction<G>::get_post_step_data(CoreState<M>& state) const
+{
+    return state.template aux_data<PostTraitsT::template Data>(
+        data_.pre_post_step_id);
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Launch a (host) kernel to generate optical distribution data post-step.
  */
 template<GeneratorType G>
 void OffloadAction<G>::offload(CoreParams const& core_params,
                                CoreStateHost& core_state) const
 {
-    auto& pre_step
-        = core_state.aux_data<PreTraitsT::template Data>(data_.pre_step_id);
+    auto& pre_step = this->get_pre_step_data(core_state);
     auto& gen_state = get<optical::GeneratorState<MemSpace::native>>(
         core_state.aux(), data_.gen_id);
     TrackExecutor execute{
@@ -137,8 +162,7 @@ void OffloadAction<G>::offload(CoreParams const& core_params,
                  gen_state.store.ref(),
                  pre_step,
                  (G == GeneratorType::scintillation)
-                     ? core_state.aux_data<PostTraitsT::template Data>(
-                           data_.pre_post_step_id)
+                     ? this->get_post_step_data(core_state)
                      : NativeRef<PostTraitsT::template Data>{},
                  gen_state.counters.buffer_size}};
     launch_action(*this, core_params, core_state, execute);
@@ -159,6 +183,24 @@ void OffloadAction<G>::offload(CoreParams const&, CoreStateDevice&) const
 
 template class OffloadAction<GeneratorType::cherenkov>;
 template class OffloadAction<GeneratorType::scintillation>;
+
+template typename OffloadAction<GeneratorType::cherenkov>::PreTraitsT::
+    template Data<Ownership::reference, MemSpace::device>&
+    OffloadAction<GeneratorType::cherenkov>::get_pre_step_data(
+        CoreState<MemSpace::device>&) const;
+template typename OffloadAction<GeneratorType::scintillation>::PreTraitsT::
+    template Data<Ownership::reference, MemSpace::device>&
+    OffloadAction<GeneratorType::scintillation>::get_pre_step_data(
+        CoreState<MemSpace::device>&) const;
+
+template typename OffloadAction<GeneratorType::cherenkov>::PostTraitsT::
+    template Data<Ownership::reference, MemSpace::device>&
+    OffloadAction<GeneratorType::cherenkov>::get_post_step_data(
+        CoreState<MemSpace::device>&) const;
+template typename OffloadAction<GeneratorType::scintillation>::PostTraitsT::
+    template Data<Ownership::reference, MemSpace::device>&
+    OffloadAction<GeneratorType::scintillation>::get_post_step_data(
+        CoreState<MemSpace::device>&) const;
 
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/celeritas/optical/gen/OffloadAction.cu
+++ b/src/celeritas/optical/gen/OffloadAction.cu
@@ -30,8 +30,7 @@ template<GeneratorType G>
 void OffloadAction<G>::offload(CoreParams const& core_params,
                                CoreStateDevice& core_state) const
 {
-    auto& pre_step
-        = core_state.aux_data<PreTraitsT::template Data>(data_.pre_step_id);
+    auto& pre_step = this->get_pre_step_data(core_state);
     auto& gen_state = get<optical::GeneratorState<MemSpace::native>>(
         core_state.aux(), data_.gen_id);
     TrackExecutor execute{
@@ -42,8 +41,7 @@ void OffloadAction<G>::offload(CoreParams const& core_params,
                  gen_state.store.ref(),
                  pre_step,
                  (G == GeneratorType::scintillation)
-                     ? core_state.aux_data<PostTraitsT::template Data>(
-                           data_.pre_post_step_id)
+                     ? this->get_post_step_data(core_state)
                      : NativeRef<PostTraitsT::template Data>{},
                  gen_state.counters.buffer_size}};
     static ActionLauncher<decltype(execute)> const launch_kernel(*this);

--- a/src/celeritas/optical/gen/OffloadAction.hh
+++ b/src/celeritas/optical/gen/OffloadAction.hh
@@ -110,6 +110,14 @@ class OffloadAction final : public CoreStepActionInterface
 
     void offload(CoreParams const&, CoreStateHost&) const;
     void offload(CoreParams const&, CoreStateDevice&) const;
+
+    template<MemSpace M>
+    typename PreTraitsT::template Data<Ownership::reference, M>&
+    get_pre_step_data(CoreState<M>& state) const;
+
+    template<MemSpace M>
+    typename PostTraitsT::template Data<Ownership::reference, M>&
+    get_post_step_data(CoreState<M>& state) const;
 };
 
 //---------------------------------------------------------------------------//

--- a/src/celeritas/optical/gen/OffloadGatherAction.cc
+++ b/src/celeritas/optical/gen/OffloadGatherAction.cc
@@ -65,6 +65,18 @@ auto OffloadGatherAction<S>::create_state(MemSpace m,
 
 //---------------------------------------------------------------------------//
 /*!
+ * Get auxiliary step data for this action.
+ */
+template<StepActionOrder S>
+template<MemSpace M>
+typename OffloadGatherAction<S>::TraitsT::template Data<Ownership::reference, M>&
+OffloadGatherAction<S>::get_step_data(CoreState<M>& state) const
+{
+    return state.template aux_data<TraitsT::template Data>(aux_id_);
+}
+
+//---------------------------------------------------------------------------//
+/*!
  * Gather pre-step data.
  */
 template<StepActionOrder S>
@@ -93,5 +105,13 @@ void OffloadGatherAction<S>::step(CoreParams const&, CoreStateDevice&) const
 template class OffloadGatherAction<StepActionOrder::pre>;
 template class OffloadGatherAction<StepActionOrder::pre_post>;
 
+template OffloadGatherAction<StepActionOrder::pre>::TraitsT::
+    template Data<Ownership::reference, MemSpace::device>&
+    OffloadGatherAction<StepActionOrder::pre>::get_step_data(
+        CoreState<MemSpace::device>&) const;
+template OffloadGatherAction<StepActionOrder::pre_post>::TraitsT::
+    template Data<Ownership::reference, MemSpace::device>&
+    OffloadGatherAction<StepActionOrder::pre_post>::get_step_data(
+        CoreState<MemSpace::device>&) const;
 //---------------------------------------------------------------------------//
 }  // namespace celeritas

--- a/src/celeritas/optical/gen/OffloadGatherAction.cu
+++ b/src/celeritas/optical/gen/OffloadGatherAction.cu
@@ -25,9 +25,10 @@ template<StepActionOrder S>
 void OffloadGatherAction<S>::step(CoreParams const& params,
                                   CoreStateDevice& state) const
 {
-    auto& step = state.aux_data<TraitsT::template Data>(aux_id_);
+    auto step = this->get_step_data(state);
     auto execute = make_active_track_executor(
         params.ptr<MemSpace::native>(), state.ptr(), Executor{step});
+
     static ActionLauncher<decltype(execute)> const launch_kernel(*this);
     launch_kernel(state, execute);
 }

--- a/src/celeritas/optical/gen/OffloadGatherAction.hh
+++ b/src/celeritas/optical/gen/OffloadGatherAction.hh
@@ -95,6 +95,12 @@ class OffloadGatherAction final : public CoreStepActionInterface,
 
     using Executor = typename TraitsT::Executor;
 
+    //// HELPER FUNCTIONS ////
+
+    template<MemSpace M>
+    typename TraitsT::template Data<Ownership::reference, M>&
+    get_step_data(CoreState<M>& state) const;
+
     //// DATA ////
 
     ActionId action_id_;


### PR DESCRIPTION
The Clang compiler and the GCC compiler have made an incompatible choice in regard to the handling of template alias used as template parameter (the standard is silent on the subject and both interpretation are 'valid' although the GCC choice seems more 'natutal').

The problem arise if Celeritas is built with Clang but uses an instance of NVCC which GCC has the host compiler.

The symptoms is a failing dynamic cast on what is seemingly a compatible/correct type.  However it turns out that Clang makes a valid but surprising interoperation of the C++ standard.  Namely when a class template is used as a template argument or an alias to that same class template is used, Clang choose to make the result type/instance distinct.

Clang failing example: https://godbolt.org/z/xW8T1PcxW
gcc is different/works: https://godbolt.org/z/Tj1PfqWeT

The problem is further limited in scope by the fact that the Celeritas code is internally consistent (and works fully when compiled with Clang for CPU only) but mixing Clang and NVCC (with gcc underneath) leads to the inconsistency.

The solution here consist in moving any code involving directly the class template instance with the class template alias as a template parameter to the `.cc` side.  This result in the need to have seeming 'simple' trampoline function template that are explicitly instantiated in the `.cc` file.

Related notes:

https://www.open-std.org/jtc1/sc22/wg21/docs/cwg_active.html#1286 https://stackoverflow.com/questions/78778437/gcc-and-clang-disagree-on-using-alias-templates-as-template-template-argument

https://github.com/llvm/llvm-project/issues/72377
https://github.com/llvm/llvm-project/issues/33002

